### PR TITLE
Feature/wpc qpf

### DIFF
--- a/dags/cumulus__acquisition__wpc_qpf.py
+++ b/dags/cumulus__acquisition__wpc_qpf.py
@@ -39,7 +39,8 @@ def download_and_process_wpc_qpf():
 
     URL_ROOT = f'https://ftp.wpc.ncep.noaa.gov'
     STATUS_SOURCE = f'{URL_ROOT}/pqpf/pqpf_status.txt'
-    STATUS_S3_KEY = f'cumulus/wpc_2p5km_qpf_status/{os.path.basename(STATUS_SOURCE)}'
+    S3_KEY_DIR = f'cumulus/wpc_qpf_2p5km'
+    STATUS_S3_KEY = f'{S3_KEY_DIR}_status/{os.path.basename(STATUS_SOURCE)}'
     PROD_SOURCE_DIR = '2p5km_qpf'
 
     @task()
@@ -98,7 +99,7 @@ def download_and_process_wpc_qpf():
 
         for hour in fcst_hrs[forecast_hour]:
             filename = f'p06m_{forecast_datetime}f{hour}.grb'
-            output = trigger_download(url=f'{URL_ROOT}/{PROD_SOURCE_DIR}/{filename}', s3_bucket='corpsmap-data-incoming', s3_key=f'cumulus/wpc_{PROD_SOURCE_DIR}/{filename}')
+            output = trigger_download(url=f'{URL_ROOT}/{PROD_SOURCE_DIR}/{filename}', s3_bucket='corpsmap-data-incoming', s3_key=f'{S3_KEY_DIR}/{filename}')
       
         # Replace the status file with new datetime contents
         output = trigger_download(url=f'{STATUS_SOURCE}', s3_bucket='corpsmap-data-incoming', s3_key=STATUS_S3_KEY)

--- a/dags/cumulus__acquisition__wpc_qpf.py
+++ b/dags/cumulus__acquisition__wpc_qpf.py
@@ -2,19 +2,21 @@
 Acquire and Process Weather Prediction Center QPF
 """
 
-import json
+import os, json, logging
+import requests
+from datetime import datetime, timedelta
 
 from airflow import DAG
 from airflow.decorators import dag, task
 
-from datetime import datetime, timedelta
+from helpers.downloads import trigger_download, read_s3_file
 
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": datetime(2021, 1, 10, 0, 0, 0),
+    "start_date": (datetime.utcnow()-timedelta(hours=2)).replace(minute=0, second=0),
     "catchup_by_default": False,
-    "email": ["airflow@airflow.com"],
+    # "email": ["airflow@airflow.com"],
     "email_on_failure": False,
     "email_on_retry": False,
     "retries": 1,
@@ -26,14 +28,83 @@ default_args = {
 }
 
 # An Example Using the Taskflow API
-@dag(default_args=default_args, schedule_interval='0 3 * * *', tags=['cumulus'])
+@dag(default_args=default_args, schedule_interval='@hourly', tags=['cumulus'])
 def download_and_process_wpc_qpf():
-    """This pipeline handles download, processing, and derivative product creation for Weather Prediction Center QPF
+    """This pipeline handles download, processing, and derivative product creation for Weather Prediction Center QPF\n
     0000 Hours Forecast : 00f  -  006, 012, 018, 024, 030, 036, 042, 048, 054, 060, 066, 072, 078, 084, 090, 096, 102, 108, 114, 120, 126, 132, 138, 144, 150, 156, 162, 168
     0600 Hours Forecast : 06f  -  006, 012, 018, 024, 030, 036, 042, 048, 054, 060, 066, 072, 078, 084, 090, 096, 102, 108, 114, 120, 126, 132, 138, 144, 150, 156, 162, 168, 174
     1200 Hours Forecast : 12f  -  006, 012, 018, 024, 030, 036, 042, 048, 054, 060, 066, 072, 078, 084, 090, 096, 102, 108, 114, 120, 126, 132, 138, 144, 150, 156, 162, 168
     1800 Hours Forecast : 18f  -  006, 012, 018, 024, 030, 036, 042, 048, 054, 060, 066, 072, 078, 084, 090, 096, 102, 108, 114, 120, 126, 132, 138, 144, 150, 156, 162, 168, 174
     """
 
-    def download_raw_data():
-        print('TODO...')
+    URL_ROOT = f'https://ftp.wpc.ncep.noaa.gov'
+    STATUS_SOURCE = f'{URL_ROOT}/pqpf/pqpf_status.txt'
+    STATUS_S3_KEY = f'cumulus/wpc_2p5km_qpf_status/{os.path.basename(STATUS_SOURCE)}'
+    PROD_SOURCE_DIR = '2p5km_qpf'
+
+    @task()
+    def check_new_forecast():
+        
+        s3_forecast_datetime = None
+        # Check S3 status file for last datetime string saved from prev request
+        s3_status_contents = read_s3_file(STATUS_S3_KEY, 'corpsmap-data-incoming')
+
+        if s3_status_contents:
+            s3_forecast_datetime = s3_status_contents[0].strip()
+            logging.info(f'S3 Forecast datetime is: {s3_forecast_datetime}')
+        else:
+            logging.warning('Status file not found in S3.')
+            # S3 forecast has no content (no file) which should only happen on
+            # first run or if somewhere deletes the file manually.
+        
+        # Get the remote status file from WPC        
+        r = requests.get(f'{STATUS_SOURCE}')
+        wpc_forecast_datetime = r.text.strip()
+        logging.info(f'WPC Forecast datetime is: {wpc_forecast_datetime}')
+
+        if s3_forecast_datetime == wpc_forecast_datetime:
+            return False
+        else:
+            return wpc_forecast_datetime
+
+
+    def generate_str_numbers(start, end, interval, char_len):
+        str_numbers = []
+        for h in range(start, end+1, interval):
+            # print(str(h).zfill(char_len))
+            str_numbers.append(str(h).zfill(char_len))
+        return str_numbers 
+    
+    
+    @task()
+    def download_raw_data(forecast_datetime):
+        # print(f'download_raw_data(): {forecast_datetime}')
+        # print(type(forecast_datetime))
+
+        # Exit early, nothing new to download
+        if forecast_datetime == False:
+            logging.info(f'Exiting early, nothing new to download.')
+            return
+
+        fcst_hrs = {
+            '00': generate_str_numbers(start=6, end=168, interval=6, char_len=3),
+            '06': generate_str_numbers(start=6, end=174, interval=6, char_len=3),
+            '12': generate_str_numbers(start=6, end=168, interval=6, char_len=3),
+            '18': generate_str_numbers(start=6, end=174, interval=6, char_len=3),
+        }
+
+        forecast_hour = forecast_datetime[-2:]
+        logging.info(f'Forecast hour is: {forecast_hour}')
+
+        for hour in fcst_hrs[forecast_hour]:
+            filename = f'p06m_{forecast_datetime}f{hour}.grb'
+            output = trigger_download(url=f'{URL_ROOT}/{PROD_SOURCE_DIR}/{filename}', s3_bucket='corpsmap-data-incoming', s3_key=f'cumulus/wpc_{PROD_SOURCE_DIR}/{filename}')
+      
+        # Replace the status file with new datetime contents
+        output = trigger_download(url=f'{STATUS_SOURCE}', s3_bucket='corpsmap-data-incoming', s3_key=STATUS_S3_KEY)
+        return
+
+    
+    download_raw_data(check_new_forecast())
+
+wpc_qpf_dag = download_and_process_wpc_qpf()

--- a/dags/cumulus__acquisition__wpc_qpf_backfill.py
+++ b/dags/cumulus__acquisition__wpc_qpf_backfill.py
@@ -1,0 +1,84 @@
+"""
+Acquire and Process Weather Prediction Center QPF
+"""
+
+import os, json, logging
+import requests
+from datetime import datetime, timedelta
+
+from airflow import DAG
+from airflow.decorators import dag, task
+from airflow.operators.python import task, get_current_context
+
+from helpers.downloads import trigger_download, read_s3_file
+
+default_args = {
+    "owner": "airflow",
+    "depends_on_past": False,
+    "start_date": (datetime.utcnow()-timedelta(days=6)).replace(hour=0, minute=0, second=0),
+    "end_date": (datetime.utcnow()-timedelta(days=1)).replace(hour=23, minute=59, second=59),
+    "catchup_by_default": False,
+    # "email": ["airflow@airflow.com"],
+    "email_on_failure": False,
+    "email_on_retry": False,
+    "retries": 1,
+    "retry_delay": timedelta(minutes=5),
+    # 'queue': 'bash_queue',
+    # 'pool': 'backfill',
+    # 'priority_weight': 10,
+}
+
+# An Example Using the Taskflow API
+@dag(default_args=default_args, schedule_interval='0 00,06,12,18 * * *', tags=['cumulus','forecast', 'backfill'])
+def download_and_process_wpc_qpf_backfill():
+    """This pipeline handles backfill download, processing, and derivative product creation for Weather Prediction Center QPF\n
+    0000 Hours Forecast : 00f  -  006, 012, 018, 024, 030, 036, 042, 048, 054, 060, 066, 072, 078, 084, 090, 096, 102, 108, 114, 120, 126, 132, 138, 144, 150, 156, 162, 168
+    0600 Hours Forecast : 06f  -  006, 012, 018, 024, 030, 036, 042, 048, 054, 060, 066, 072, 078, 084, 090, 096, 102, 108, 114, 120, 126, 132, 138, 144, 150, 156, 162, 168, 174
+    1200 Hours Forecast : 12f  -  006, 012, 018, 024, 030, 036, 042, 048, 054, 060, 066, 072, 078, 084, 090, 096, 102, 108, 114, 120, 126, 132, 138, 144, 150, 156, 162, 168
+    1800 Hours Forecast : 18f  -  006, 012, 018, 024, 030, 036, 042, 048, 054, 060, 066, 072, 078, 084, 090, 096, 102, 108, 114, 120, 126, 132, 138, 144, 150, 156, 162, 168, 174
+
+    The WPC Archive appears to only go back 5-6 days.
+    Backfill for WPC QPF Products will use time range: Start:now-6days, End:now-1day
+    """
+
+    URL_ROOT = f'https://ftp.wpc.ncep.noaa.gov'
+    #STATUS_SOURCE = f'{URL_ROOT}/pqpf/pqpf_status.txt'
+    #STATUS_S3_KEY = f'cumulus/wpc_2p5km_qpf_status/{os.path.basename(STATUS_SOURCE)}'
+    PROD_SOURCE_DIR = '2p5km_qpf'
+
+
+    def generate_str_numbers(start, end, interval, char_len):
+        str_numbers = []
+        for h in range(start, end+1, interval):
+            # print(str(h).zfill(char_len))
+            str_numbers.append(str(h).zfill(char_len))
+        return str_numbers 
+    
+    
+    @task()
+    def download_raw_data():
+                
+        execution_date = get_current_context()['execution_date']
+        forecast_datetime = execution_date.strftime("%Y%m%d%H")
+        logging.info(f'Downloading for Forecast Set: {forecast_datetime}')
+
+        fcst_hrs = {
+            '00': generate_str_numbers(start=6, end=168, interval=6, char_len=3),
+            '06': generate_str_numbers(start=6, end=174, interval=6, char_len=3),
+            '12': generate_str_numbers(start=6, end=168, interval=6, char_len=3),
+            '18': generate_str_numbers(start=6, end=174, interval=6, char_len=3),
+        }
+
+        forecast_hour = forecast_datetime[-2:]
+        logging.info(f'Forecast hour is: {forecast_hour}')
+
+        for hour in fcst_hrs[forecast_hour]:
+            filename = f'p06m_{forecast_datetime}f{hour}.grb'
+            output = trigger_download(url=f'{URL_ROOT}/{PROD_SOURCE_DIR}/{filename}', s3_bucket='corpsmap-data-incoming', s3_key=f'cumulus/wpc_{PROD_SOURCE_DIR}/{filename}')
+      
+        return
+
+    
+    download_raw_data()
+
+wpc_qpf_dag = download_and_process_wpc_qpf_backfill()

--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -1,0 +1,35 @@
+version: '3'
+
+networks:
+  default:
+    external:
+      name: cumulus-api_default
+
+services:
+  minio:
+    image: minio/minio
+    environment:
+      - MINIO_ACCESS_KEY=AKIAIOSFODNN7EXAMPLE
+      - MINIO_SECRET_KEY=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+    command: server /data
+    ports:
+      - '9000:9000'
+  # configure minio on startup (create buckets, etc)
+  # inspired by https://github.com/minio/minio/issues/4769
+  # and         https://gist.github.com/haxoza/22afe7cc4a9da7e8bdc09aad393a99cc
+  minio_init:
+    image: minio/mc
+    depends_on:
+      - minio
+    entrypoint: >
+      /bin/sh -c "
+      echo 'sleeping for 10 seconds while minio starts...';
+      sleep 10;
+      /usr/bin/mc config host add minio http://minio:9000 AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY;
+      /usr/bin/mc mb   minio/corpsmap-data-incoming   minio/corpsmap-data;
+      /usr/bin/mc policy set public minio/corpsmap-data;
+      /usr/bin/mc cp --recursive /media/ minio/corpsmap-data/cumulus/;
+      exit 0;
+      "
+    volumes:
+      - ./data:/media


### PR DESCRIPTION
Caveat to the hourly running dag...Since the canary file is used to determine the forecast set to pull, trying to replay a past execution will look at the current canary file.  For this reason, replaying a past execution should be avoided.  The back-fill dag can be used to download the last 5-6 days (that's all I see in the same WPC directory).  Back-fill start_date is set to now-6days.  end_date is set to now-1day.  Manual changes can be done, but it requires editing the git repo code/DAG.  Thought about allowing an env_var to override so it could all be controlled via web interface.