### PR TITLE
Bugfix/update airflow container tag

### DIFF
--- a/docker-compose.minio.yml
+++ b/docker-compose.minio.yml
@@ -26,9 +26,9 @@ services:
       echo 'sleeping for 10 seconds while minio starts...';
       sleep 10;
       /usr/bin/mc config host add minio http://minio:9000 AKIAIOSFODNN7EXAMPLE wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY;
-      /usr/bin/mc mb   minio/corpsmap-data-incoming   minio/corpsmap-data;
-      /usr/bin/mc policy set public minio/corpsmap-data;
-      /usr/bin/mc cp --recursive /media/ minio/corpsmap-data/cumulus/;
+      /usr/bin/mc mb minio/cwbi-data-develop minio/cwbi-data-stable;
+      /usr/bin/mc policy set public minio/cwbi-data-develop;
+      /usr/bin/mc policy set public minio/cwbi-data-stable;
       exit 0;
       "
     volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: "3"
+version: '3'
 
 networks:
   default:
@@ -14,13 +14,13 @@ services:
       - ./database/sql/init.sql:/docker-entrypoint-initdb.d/z_init.sql
     environment:
       - POSTGRES_PASSWORD=postgres
-    # ports:
-    #   - "5432:5432"
+    ports:
+      - '5432:5432'
 
   airflow_init:
     env_file:
       - ./airflow.env
-    image: apache/airflow:master-python3.8
+    image: apache/airflow:main-python3.8
     depends_on:
       - airflowdb
     entrypoint: >
@@ -33,7 +33,7 @@ services:
   airflow_scheduler:
     env_file:
       - ./airflow.env
-    image: apache/airflow:master-python3.8
+    image: apache/airflow:main-python3.8
     depends_on:
       - airflow_init
     restart: always
@@ -45,12 +45,12 @@ services:
   airflow_ui:
     env_file:
       - ./airflow.env
-    image: apache/airflow:master-python3.8
+    image: apache/airflow:main-python3.8
     depends_on:
       - airflow_init
       - airflow_scheduler
     restart: always
     # environment:
     ports:
-      - "8000:8080"
+      - '8000:8080'
     command: webserver

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,8 +14,8 @@ services:
       - ./database/sql/init.sql:/docker-entrypoint-initdb.d/z_init.sql
     environment:
       - POSTGRES_PASSWORD=postgres
-    ports:
-      - '5432:5432'
+    # ports:
+    #   - '5432:5432'
 
   airflow_init:
     env_file:


### PR DESCRIPTION
Airflow would not load dags on a brand new computer setup.  After removing all images/volumes on existing dev machine, same issue appeared.  Errors seemed to indicate a field needed in the database wasn't present.  Could be more.  After several hours of troubleshooting, i tried another dockerhub tag "main" instead of "master" (apache/airflow:main-python3.8) for the docker-compose image.  Seems to work in local testing now.