### PR TITLE
adjust dag logic

### DIFF
--- a/dags/cumulus/lmrfc_qpf.py
+++ b/dags/cumulus/lmrfc_qpf.py
@@ -10,6 +10,7 @@ QPF --> ORN_QPF_SFC_20210822ZZ_FFF_2021082306fFFF.grb.gz
 """
 
 from datetime import datetime, timedelta
+import logging
 
 from airflow import DAG
 
@@ -31,13 +32,14 @@ implementation = {
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": (datetime.utcnow() - timedelta(hours=12)).replace(minute=0, second=0),
+    "start_date": (datetime.utcnow() - timedelta(hours=24)).replace(minute=0, second=0),
     "catchup_by_default": False,
     "email_on_failure": False,
     "email_on_retry": False,
-    "retries": 2,
+    "retries": 4,
     "retry_delay": timedelta(minutes=30),
 }
+
 
 # ALR QPF filename generator
 def qpf_filenames(edate):
@@ -81,11 +83,23 @@ def create_dag(**kwargs):
             ti = context["ti"]
             execution_date = ti.execution_date
 
+            # Force the window forward 6 hours to get the latest forecast set now and not from the prev interval
+            execution_date = execution_date + timedelta(hours=6)
+
             return_list = list()
             for filename in qpf_filenames(execution_date):
                 url = f"{base_url}/{filename}"
                 s3_key = f"{key_prefix}/{slug}/{filename}"
-                result = trigger_download(url=url, s3_bucket=s3_bucket, s3_key=s3_key)
+                # This RFC has been known to not include all files each time - this is a patch
+                try:
+                    result = trigger_download(
+                        url=url, s3_bucket=s3_bucket, s3_key=s3_key
+                    )
+                except:
+                    if len(return_list) > 0:
+                        # There have been successfull downloads, don't blow up the whole task
+                        logging.warning(f"Unable to download {url}")
+                        pass
                 return_list.append(
                     {
                         "execution": execution_date.isoformat(),
@@ -126,5 +140,5 @@ for key, val in implementation.items():
         dag_id=d_id,
         tags=d_tags,
         s3_bucket=d_bucket,
-        schedule="8 */3 * * *",
+        schedule="8 0,12,18 * * *",
     )


### PR DESCRIPTION
https://github.com/USACE/cumulus/issues/404

- This should allow missing files as long as one is successful.
- The download task should not blow up with one or more missing files, only no files were downloaded
- Airflow dag has also been adjusted to check the forecasts for the current period and not the prev period
  - 2 additional tries added (30 min each) to provide additional time for the forecast set