### PR TITLE
Apply airflow constraints file to additional deps

### DIFF
--- a/_docker/airflow/Dockerfile
+++ b/_docker/airflow/Dockerfile
@@ -678,6 +678,7 @@ function install_additional_dependencies() {
         echo
         set -x
         pip install --root-user-action ignore --upgrade --upgrade-strategy eager \
+        --constraint "${AIRFLOW_CONSTRAINTS_LOCATION}" \
             ${ADDITIONAL_PIP_INSTALL_FLAGS} \
             ${ADDITIONAL_PYTHON_DEPS} ${EAGER_UPGRADE_ADDITIONAL_REQUIREMENTS}
         # make sure correct PIP version is used
@@ -693,6 +694,7 @@ function install_additional_dependencies() {
         echo
         set -x
         pip install --root-user-action ignore --upgrade --upgrade-strategy only-if-needed \
+        --constraint "${AIRFLOW_CONSTRAINTS_LOCATION}" \
             ${ADDITIONAL_PIP_INSTALL_FLAGS} \
             ${ADDITIONAL_PYTHON_DEPS}
         # make sure correct PIP version is used


### PR DESCRIPTION
Installation of celery[redis] is causing conflicts with base airflow packages (specifically async-timeout, which recently updated to v5). Apply apache's auto-generated airflow/python version constraints file to the additional python dependencies installation workflow to avoid this issue.