### PR TITLE
update schedule to better match posting time of grids 15 9,15,19 * * *

### DIFF
--- a/dags/cumulus/aprfc_qtf_01h.py
+++ b/dags/cumulus/aprfc_qtf_01h.py
@@ -72,7 +72,7 @@ def get_filenames(edate, url):
 
 @dag(
     default_args=default_args,
-    schedule="40 5,23 * * *",
+    schedule="21 9,15,19 * * *",
     tags=["cumulus", "temp", "QTF", "APRFC"],
     max_active_runs=1,
     max_active_tasks=1,


### PR DESCRIPTION
update schedule to better match web posting time of grids by district/division....they will edit their post job to run at `15 9,15,19 * * *`  to address lag time discussed in https://github.com/USACE/cumulus/issues/431

if district/division is obtaining grids via ldm, we may need to consider obtaining via ldm if RFC can't or won't post them