### PR TITLE
Fix aprfc qpf and qtf - add try block for s3 check

### DIFF
--- a/dags/cumulus/aprfc_qpf_06h.py
+++ b/dags/cumulus/aprfc_qpf_06h.py
@@ -102,7 +102,7 @@ def get_filenames(edate, url):
 
 @dag(
     default_args=default_args,
-    schedule="20 9,15,19 * * *",
+    schedule="25 * * * *",
     tags=["cumulus", "precip", "QPF", "APRFC"],
     max_active_runs=1,
     max_active_tasks=1,
@@ -126,10 +126,13 @@ def cumulus_aprfc_qpf_06h():
         for filename in filenames:
             url = f"{URL_ROOT}/{filename}"
             s3_key = f"{key_prefix}/{PRODUCT_SLUG}/{filename}"
-            # Check if the file already exists in S3
-            if s3_file_exists(cumulus.S3_BUCKET, s3_key):
-                print(f"Skipping existing S3 object: s3://{cumulus.S3_BUCKET}/{s3_key}")
-                continue  # Skip to the next file
+            try:
+                # Check if the file already exists in S3
+                if s3_file_exists(cumulus.S3_BUCKET, s3_key):
+                    print(f"Skipping existing S3 object: s3://{cumulus.S3_BUCKET}/{s3_key}")
+                    continue  # Skip to the next file
+            except:
+                print(f'Error checking S3 for {s3_key}')
             print(f"Downloading file: {filename}")
             try:
                 trigger_download(url=url, s3_bucket=cumulus.S3_BUCKET, s3_key=s3_key)

--- a/dags/cumulus/aprfc_qtf_01h.py
+++ b/dags/cumulus/aprfc_qtf_01h.py
@@ -105,7 +105,7 @@ def get_filenames(edate, url):
 
 @dag(
     default_args=default_args,
-    schedule="21 9,15,19 * * *",
+    schedule="25 * * * *",
     tags=["cumulus", "temp", "QTF", "APRFC"],
     max_active_runs=1,
     max_active_tasks=1,
@@ -129,10 +129,13 @@ def cumulus_aprfc_qtf_01h():
         for filename in filenames:
             url = f"{URL_ROOT}/{filename}"
             s3_key = f"{key_prefix}/{PRODUCT_SLUG}/{filename}"
-            # Check if the file already exists in S3
-            if s3_file_exists(cumulus.S3_BUCKET, s3_key):
-                print(f"Skipping existing S3 object: s3://{cumulus.S3_BUCKET}/{s3_key}")
-                continue  # Skip to the next file
+            try:
+                # Check if the file already exists in S3
+                if s3_file_exists(cumulus.S3_BUCKET, s3_key):
+                    print(f"Skipping existing S3 object: s3://{cumulus.S3_BUCKET}/{s3_key}")
+                    continue  # Skip to the next file
+            except:
+                print(f'Error checking S3 for {s3_key}')
             print(f"Downloading file: {filename}")
             try:
                 trigger_download(url=url, s3_bucket=cumulus.S3_BUCKET, s3_key=s3_key)


### PR DESCRIPTION
Copy of https://github.com/USACE/airflow-config/pull/354 but with fix for failing S3 file check.


This PR fixes the changes in filename on https://cbt.crohms.org/akgrids/ for the aprfc qpf and qtf grids. Added a check to see if the acquirable exists in S3 before downloading to prevent downloads. Will only acquire the latest forecast issuance.

Tested both products locally. Geoprocs work, but there is still the old name in the geoproc test data. Didn't seem to matter.

Fixes https://github.com/USACE/cumulus/issues/454