### PR TITLE
Refactor Stage4 Precip Revisions

### DIFF
--- a/dags/cumulus/ncep_stage4_conus_01h_revision.py
+++ b/dags/cumulus/ncep_stage4_conus_01h_revision.py
@@ -1,5 +1,5 @@
 """
-Acquire and Process NCEP Stage 4 MOSAIC QPE
+Acquire and Process NCEP Stage 4 MOSAIC QPE Revisions
 """
 
 import os, json, logging, time
@@ -19,7 +19,7 @@ import helpers.cumulus as cumulus
 default_args = {
     "owner": "airflow",
     "depends_on_past": False,
-    "start_date": (datetime.now(timezone.utc) - timedelta(days=7)).replace(
+    "start_date": (datetime.now(timezone.utc) - timedelta(hours=1)).replace(
         minute=0, second=0
     ),
     "catchup_by_default": True,
@@ -32,12 +32,12 @@ default_args = {
 
 @dag(
     default_args=default_args,
-    schedule="0 * * * *",
-    tags=["cumulus", "precip", "QPE", "CONUS", "stage4", "NCEP"],
-    max_active_runs=2,
-    max_active_tasks=4,
+    schedule="0 18 * * *",
+    tags=["cumulus", "precip", "QPE", "CONUS", "stage4", "NCEP", 'revision'],
+    max_active_runs=1,
+    max_active_tasks=2,
 )
-def cumulus_ncep_stage4_conus_01h():
+def cumulus_ncep_stage4_conus_01h_revision():
     """This pipeline handles download, processing, and derivative product creation for \n
     NCEP Stage 4 MOSAIC QPE\n
     URL Dir - https://nomads.ncep.noaa.gov/pub/data/nccf/com/pcpanl/prod/pcpanl.20220808/st4_conus.YYYYMMHHMM.01h.grb2\n
@@ -57,19 +57,6 @@ def cumulus_ncep_stage4_conus_01h():
         )
         return s3_key
 
-    @task()
-    def download_stage4_qpe():
-
-        logical_date = get_current_context()["logical_date"]
-        dirpath = f'pcpanl.{logical_date.strftime("%Y%m%d")}'
-        filename = f'st4_conus.{logical_date.strftime("%Y%m%d%H")}.01h.grb2'
-        filepath = f"{dirpath}/{filename}"
-
-        s3_key = download_product(filepath)
-
-        return json.dumps(
-            [{"datetime": logical_date.isoformat(), "s3_key": s3_key}],
-        )
 
     @task()
     def notify_cumulus(payload):
@@ -84,7 +71,37 @@ def cumulus_ncep_stage4_conus_01h():
                 s3_key=p["s3_key"],
             )
 
-    notify_cumulus(download_stage4_qpe())
+    @task()
+    def download_stage4_qpe_revision():
+
+        n = 24*14  # how many products back to download
+        logical_date = get_current_context()["logical_date"]
+        payload = []
+
+        for h in range(1, n + 1):
+            # Skip current hour, we just downloaded it in another dag
+            lookback_date = logical_date - timedelta(hours=h)
+            # logging.info(f"lookback_date: {lookback_date}")
+            dirpath = f'pcpanl.{lookback_date.strftime("%Y%m%d")}'
+            filename = f'st4_conus.{lookback_date.strftime("%Y%m%d%H")}.01h.grb2'
+            filepath = f"{dirpath}/{filename}"
+            try:
+                s3_key = download_product(filepath)
+                payload.append(
+                    {"datetime": lookback_date.isoformat(), "s3_key": s3_key}
+                )
+            except Exception as err:
+                logging.error(f"Failed to download {filepath}.")
+                logging.error(err)
+                # prevent a single failure from stopping the whole task
+                pass
+
+            # sleep to avoid hitting a rate limit on src server
+            # time.sleep(2)
+
+        return json.dumps(payload)
+
+    notify_cumulus(download_stage4_qpe_revision())
 
 
-stage4_dag = cumulus_ncep_stage4_conus_01h()
+stage4_dag = cumulus_ncep_stage4_conus_01h_revision()


### PR DESCRIPTION
Broke the Stage4 revisions out to its own DAG to run once a day and changed the hourly DAG to just grab the latest hour. Addresses https://github.com/USACE/cumulus/issues/458 to go back 2 weeks to get all revisions.